### PR TITLE
Fix for CVE-2024-47554 - update to commons-io 2.14.0

### DIFF
--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -21,7 +21,7 @@
         <lombok.version>1.18.12</lombok.version>
 
         <junit.version>4.13.1</junit.version>
-        <commons-io.version>2.7</commons-io.version>
+        <commons-io.version>2.14.0</commons-io.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Fix for CVE-2024-47554 - update to commons-io 2.14.0

*Issue #, if available:*
CVE-2024-47554

*Description of changes:*
update to commons-io 2.14.0


